### PR TITLE
better UI/UX in this padding

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -387,7 +387,7 @@ Nav bar
 }
 
 .counter-item .ci-text {
-  padding-left: 170px;
+  padding-left: 150px;
 }
 
 .counter-item .ci-text h4 {


### PR DESCRIPTION
In the mobile view the achievements was too much shifted on the right side. 

Before
![Screenshot from 2020-04-04 17-04-17](https://user-images.githubusercontent.com/55639487/78449410-f9b8d280-7697-11ea-80f6-d77b6af473b8.png)

After
![Screenshot from 2020-04-04 17-08-53](https://user-images.githubusercontent.com/55639487/78449541-02a9a400-7698-11ea-9036-305294c816dc.png)
