### PR TITLE
add action forge publish

### DIFF
--- a/.github/workflows/action-forge.yml
+++ b/.github/workflows/action-forge.yml
@@ -1,0 +1,20 @@
+name: Build and publish to Puppet Forge
+on:
+ push:
+  tags:
+      - v[0-9]+.[0-9]+.[0-9]+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Get latest tag
+      run: echo ::set-env name=RELEASE_VERSION::$(echo ${GITHUB_REF:10})
+    - name: Clone repository
+      uses: actions/checkout@v1
+      with:
+        ref: ${{ env.RELEASE_VERSION }}
+    - name: Build and publish module
+      uses: barnumbirr/action-forge-publish@v1.2.0
+      env:
+       FORGE_API_KEY: ${{ secrets.FORGE_API_KEY }}
+       REPOSITORY_URL: https://forgeapi.puppet.com/v3/releases


### PR DESCRIPTION
this is very useful action as it allows users to users to build and publish their tools on puppet forge.

related #122 