### PR TITLE
added github action to auto label merge conflicts

### DIFF
--- a/.github/workflows/auto-label-merge-conflicts.yml
+++ b/.github/workflows/auto-label-merge-conflicts.yml
@@ -1,0 +1,13 @@
+on:
+  push:
+    branches:
+      - master
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: mschilde/auto-label-merge-conflicts@master
+        with:
+          CONFLICT_LABEL_NAME: "has conflicts"
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+


### PR DESCRIPTION
The typical use case is to run this action post merge (e.g. push to master) to quickly see which other PRs are now in conflict.

Related to #122 