### PR TITLE
working on event1.html

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1684,6 +1684,17 @@ html{
   -o-transition: all 0.3s;
   transition: all 0.3s;
 }
+
+@media only screen and (max-width: 540px) {
+  .material-card .mc-btn-action {
+    right: 0px;
+    top: 29px;
+    width: 45px;
+    height: 47px;
+    line-height: 40px;
+  }
+}
+
 .material-card.mc-active .mc-btn-action {
   top: 62px;
 }


### PR DESCRIPTION
Fixed mc-btn colliding with the content.


Working on #158 


Issue :- in the mobile view the mc-btn collides with the image contents
 

Pr :- it fixes this issue in the mobile view by changing the properties using the media query in css.

Before

![Screenshot from 2020-04-05 22-14-44](https://user-images.githubusercontent.com/55639487/78504449-fa7e6100-778a-11ea-8a6e-fe777699b58b.png)

After

![Screenshot from 2020-04-05 20-38-22](https://user-images.githubusercontent.com/55639487/78504454-ffdbab80-778a-11ea-8c35-a041e82977c2.png)


