### PR TITLE
added support for js incompatible devices

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,7 +20,9 @@
     <link rel="stylesheet" href="css/style.css" type="text/css">
     <link href="https://fonts.googleapis.com/css2?family=Raleway:wght@600&display=swap" rel="stylesheet">
     <script src="https://code.jquery.com/jquery-3.4.1.slim.min.js" integrity="sha384-J6qa4849blE2+poT4WnyKhv5vZF5SrPo0iEjwBvKU7imGFAV0wwj1yYfoRSJoZ+n" crossorigin="anonymous"></script>
- 
+    <script type="text/javascript">
+      document.getElementsByTagName('html')[0].className += ' Q_js'; // better than noscript
+    </script>
 </head>
 
 <body onLoad="typeWriter()">


### PR DESCRIPTION
Devices that don' support javascript will have a notification link telling them to enable javascript inorder to use the preference tool.The notification is also a link that points to steps on how to enable javascript on their devices