### PR TITLE
Sitemapping Tree addition for  seo improvement

### DIFF
--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,4 +1,3 @@
-
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
 

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,6 +1,6 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
-<urlset>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
 
 <url>
 	<loc>https://girlscriptboilerplate.netlify.app/</loc>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,36 @@
+
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset>
+
+<url>
+	<loc>https://girlscriptboilerplate.netlify.app/</loc>
+	<changefreq>daily</changefreq>
+	<priority>1.00</priority>
+</url>
+<url>
+	<loc>https://girlscriptboilerplate.netlify.app/announcements.html</loc>
+	<changefreq>daily</changefreq>
+	<priority>1.00</priority>
+</url>
+<url>
+	<loc>https://girlscriptboilerplate.netlify.app/team.html</loc>
+	<changefreq>daily</changefreq>
+	<priority>0.85</priority>
+</url>
+<url>
+	<loc>https://girlscriptboilerplate.netlify.app/achievements.html</loc>
+	<changefreq>daily</changefreq>
+	<priority>0.85</priority>
+</url>
+<url>
+	<loc>https://girlscriptboilerplate.netlify.app/blogs.html</loc>
+	<changefreq>daily</changefreq>
+	<priority>0.85</priority>
+</url>
+<url>
+	<loc>https://girlscriptboilerplate.netlify.app/contactus</loc>
+	<changefreq>daily</changefreq>
+	<priority>0.85</priority>
+</url>
+</urlset>
+ 


### PR DESCRIPTION
#34 

- Addition of sitemaps tree on the root to improve crawling for SEO
- The site can be viewed on `https://girlscriptboilerplate.netlify.app/sitemap.xml` after  the merge or can be viewed using online XML viewer tools 
- Set up to protocol 0.9 schema's
- Set the index and announcements are the highest change priority of `1` and rest to `0.85`

@anushbhatia Sir, can you review this. Thank you!