### PR TITLE
Caching Image on home page to cache storage of browsers

### DIFF
--- a/index.html
+++ b/index.html
@@ -415,5 +415,6 @@
   gtag('js', new Date());
   gtag('config', 'UA-164715490-1');
 </script>
-<script src="./scripts/optimization.js"></script>
+<!-- <script src="./scripts/optimization.js"></script> -->
+<script src="./scripts/cacheImages.js"></script>
 </html>

--- a/scripts/cacheImages.js
+++ b/scripts/cacheImages.js
@@ -1,0 +1,42 @@
+async function cacheImages() {
+  try {
+    const cache = await caches.open("girl-script");
+    const urls = [
+      "/assets/Images/logo/logo_for_boilerplate_1.png",
+      "/assets/Images/index/ml.jpg",
+      "/assets/Images/index/IoT1.jpg",
+      "/assets/Images/index/program.jpg",
+      "/assets/Images/index/cloud1.jpg",
+      "/assets/Images/index/cs3.jpg",
+      "/assets/Images/index/robot1.jpg",
+      "/assets/Images/Front-img/event.jpg",
+      "/assets/Images/logo/Logo1.png",
+      "/assets/Images/logo/logo.png",
+    ];
+    cache.addAll(urls);
+  } catch (err) {
+    console.log("Items already added!");
+  }
+}
+
+async function findImages() {
+  const cacheNames = await caches.keys();
+  const result = [];
+
+  for (const name of cacheNames) {
+    const cache = await caches.open(name);
+
+    for (const request of await cache.keys()) {
+      if (request.url.endsWith(".jpg") || request.url.endsWith(".png")) {
+        result.push(await cache.match(request));
+      }
+    }
+  }
+
+  // console.log(result);
+}
+
+// method to cache: only cache home page images
+cacheImages();
+// displays the cache items
+findImages();


### PR DESCRIPTION
#600 
I have utilized the cache-store in browsers to cache in images of the home page.
You can see the difference by going to developer tools, application, and checking cache storage.
The current app doesn't cache anything  (can be verified by checking cache storage)

Will improve it by removing cache based on time and another factor.
@anushbhatia Sir, you may review this. The rest of the information I have send on slack.
Thank you!
name of cache store:`girl-script`
**Cache Storage After addition of script will look like this:** 

![Screenshot (185)](https://user-images.githubusercontent.com/49617450/81210686-da42fb80-8fef-11ea-8f1b-0e12d79e029c.png)
