### PR TITLE
:feat: => budget.json 

### DIFF
--- a/scripts/budget.json
+++ b/scripts/budget.json
@@ -1,0 +1,47 @@
+
+[
+    {
+      "path": "/*",
+      "options": {
+         "firstPartyHostnames": ["*.my-site.com", "my-site.cdn.com"]
+      },
+      "timings": [
+        {
+          "metric": "interactive",
+          "budget": 5000
+        },
+        {
+          "metric": "first-meaningful-paint",
+          "budget": 2000
+        }
+      ],
+      "resourceSizes": [
+        {
+          "resourceType": "total",
+          "budget": 500
+        },
+        {
+          "resourceType": "script",
+          "budget": 150
+        }
+      ],
+      "resourceCounts": [
+        {
+          "resourceType": "third-party",
+          "budget": 100
+        }
+      ]
+    },
+    {
+      "options": {
+         "firstPartyHostnames": ["*.my-site.com", "my-site.cdn.com"]
+      },
+      "path": "/checkout",
+      "resourceSizes": [
+        {
+          "resourceType": "script",
+          "budget": 200
+        }
+      ]
+    }
+  ]


### PR DESCRIPTION
Added budget.json to increase the web app performance.

It supports three types of budgets:-

1. Timing budgets: Assert thresholds for time-based performance metrics like First Contentful Paint,  
    Maximum First Input Delay, and Speed Index.
2. Resource counts: Assert thresholds for the quantity of resources on a page. These thresholds can
    be defined per resource type or for the page overall.
3. Resource sizes: Assert thresholds for the transfer size of resources on a page. These thresholds    
    can be defined per resource type or for the page overall.

It is required to increase the web app performance.

Related to #519 
