### PR TITLE
Bug blogs page

### DIFF
--- a/blogs.html
+++ b/blogs.html
@@ -88,12 +88,7 @@ integrity="sha256-eZrrJcwDc/3uDhsdt61sL2oOBY362qM3lon1gyExkL0=" crossorigin="ano
             <div class="smallBox"></div>
         </div>
     </div>
-    <section class="blogs-section">
-        <div class="mb-3 p-sm-6 container width2" id="blogid">
-                    <h3 class="pt-5 pb-5 font-weight-bold heading-blog"> Recent <span> Blogs </span> </h3>
-                    <div id="retainable-rss-embed" data-rss="https://medium.com/feed/techequilla" data-maxcols="1" data-layout="grid" data-poststyle="inline" data-readmore="Read more" data-buttonclass="btn blog-btn p-3o" data-offset="-100"></div>
-        </div>
-    </section>
+   
     <!-- Footer -->
 
 	<a class="gotopbtn clr-wt" id="topBtn" style="display: none;"> <i class="fa fa-chevron-up clr-wt"></i> </a>

--- a/blogs.html
+++ b/blogs.html
@@ -89,6 +89,17 @@ integrity="sha256-eZrrJcwDc/3uDhsdt61sL2oOBY362qM3lon1gyExkL0=" crossorigin="ano
         </div>
     </div>
    
+
+    <section class="blogs-section">
+        <div class="mb-3 p-sm-6 container width2" id="blogid">
+            <h3 class="pt-5 pb-5 font-weight-bold heading-blog">
+                Recent <span> Blogs </span>
+            </h3>
+            <div id="retainable-rss-embed" data-rss="https://medium.com/feed/techequilla" data-maxcols="1"
+                data-layout="grid" data-poststyle="external" data-readmore="Read more" data-buttonclass="btn blog-btn p-3o"
+                data-offset="-100"></div>
+        </div>
+    </section>
     <!-- Footer -->
 
 	<a class="gotopbtn clr-wt" id="topBtn" style="display: none;"> <i class="fa fa-chevron-up clr-wt"></i> </a>

--- a/blogs.html
+++ b/blogs.html
@@ -102,10 +102,6 @@ integrity="sha256-eZrrJcwDc/3uDhsdt61sL2oOBY362qM3lon1gyExkL0=" crossorigin="ano
     </section>
     <!-- Footer -->
 
-	<a class="gotopbtn clr-wt" id="topBtn" style="display: none;"> <i class="fa fa-chevron-up clr-wt"></i> </a>
-
-</body>
-
 <script>
     $(".btn").mousedown(function(e){
     e.preventDefault();

--- a/css/blogs.css
+++ b/css/blogs.css
@@ -152,7 +152,6 @@ Blog Cards
 #blogid {
   margin-top: 6rem;
   -webkit-box-align: center;
-  -webkit-align-items: center;
   -ms-flex-align: center;
   align-items: center;
   max-width: 700px;
@@ -209,11 +208,9 @@ Blog Cards
   box-shadow: 0 2px 7px 0px #ff9a0e;
   margin: 1rem auto;
   display: -webkit-box;
-  display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
   width: 144px;


### PR DESCRIPTION
**Bugfix: Blogs Page**

Steps to produce bug:
Go to **mobile view**, and open the first article using **read more**  button.
- The contents (including all external links will go out of the content box)
- The hyperlinks which say `See all posts` `View the original post` and `next` will not be aligned and centered correctly.
- the page experiences x-axis scroll at 500-600 range as well

Reason:
- the blogs are embedded using external tooling retainable.io which only gives the flexibility to style a few components on blogs. (can be found on docs)

Fix:
- open the blogs natively on their workspace (this case medium website) rather than their default in-page behavior 
- fixed a few web kits 
- removed strayed out scripts

Now it work even on the smallest screens