### PR TITLE
:feat: *defer parsing* of achievements.js

### DIFF
--- a/achievements.html
+++ b/achievements.html
@@ -104,10 +104,7 @@ This project is also meant to be a starting for all techies interested to get th
 	<link rel="stylesheet" href="css/style.css" type="text/css" />
 	<link rel="stylesheet" href="css/achievement.css" type="text/css" />
 	<link rel="icon" href="assets/Images/gs.png" type="image/png" sizes="16x16">
-
-	<!-- Defined scripts -->
-	<script src="./scripts/achievement.js"></script>
-	</head>
+</head>
 
 <body class="col1">
 	<!-- Header -->
@@ -417,6 +414,7 @@ This project is also meant to be a starting for all techies interested to get th
   <a class="gotopbtn clr-wt" id="topBtn" style="display: none;"> <i class="fa fa-chevron-up clr-wt"></i> </a>
     <!--External JS File-->
     <script src="./scripts/app.js"></script>
+    <script src="./scripts/achievement.js"></script>
 	
 	 <!-- Global site tag (gtag.js) - Google Analytics -->
 	<script async src="https://www.googletagmanager.com/gtag/js?id=UA-164715490-1"></script>
@@ -425,6 +423,20 @@ This project is also meant to be a starting for all techies interested to get th
 		function gtag() { dataLayer.push(arguments); }
 		gtag('js', new Date());
 		gtag('config', 'UA-164715490-1');
+
+		// Defer Parsing of JS 
+
+	function downloadJSAtOnload() {
+		var element = document.createElement("script");
+		element.src = "./scripts/achievement.js";
+		document.body.appendChild(element);
+	}
+	if (window.addEventListener)
+		window.addEventListener("load", downloadJSAtOnload, false);
+	else if (window.attachEvent)
+		window.attachEvent("onload", downloadJSAtOnload);
+	else window.onload = downloadJSAtOnload;
+
 	</script>
 <script src="./scripts/cacheImages.js"></script>
 


### PR DESCRIPTION
The aim of the defer is to minimize the amount of time that html parsing is paused in order to deal with downloading and executing JS.

**Reasons to do this**

1. Mostly **animation.js** is used for the projects transition effect or the onClick properties so we    
    dont want the file animation.js file to load when the load the achievements.html page.
2. The script was loading in the head tag of the html. So written in last of the body tag.

So we can avoid it by defer parsing of the achievements.js as the file will not load in the initial period and once the page layout has been loaded the the JS will automatically be loaded. This will increase the speed.

Related to #519 