### PR TITLE
enabled keepAlive for PersistentConnection

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -84,3 +84,28 @@ Header set Cache-Control "max-age=31536000, public"
 <filesMatch ".(css|js)$">
 Header set Cache-Control "max-age=2628000, public"
 </filesMatch>
+
+# Enable keep-alive using .htaccess
+
+<ifModule mod_headers.c> Header set Connection keep-alive </ifModule>
+
+# For APACHE
+
+#
+# KeepAlive: Whether or not to allow persistent connections (more than
+# one request per connection). Set to "Off" to deactivate.
+#
+KeepAlive On
+
+#
+# MaxKeepAliveRequests: The maximum number of requests to allow
+# during a persistent connection. Set to 0 to allow an unlimited amount.
+# We recommend you leave this number high, for maximum performance.
+#
+MaxKeepAliveRequests 100
+
+#
+# KeepAliveTimeout: Number of seconds to wait for the next request from the
+# same client on the same connection.
+#
+KeepAliveTimeout 100


### PR DESCRIPTION
**Enabling keepAlive**

1. Keep alive is a method to allow the same tcp connection for HTTP conversation instead of opening     a new one with each new request. 
2. More simply put, it is a communication between the web server and the web browser that says "you can grab more than just one file at a time". 
3. Keep alive is also known as a persistant connection

    How to enable keep-alive?

1. Keep-alive is enabled using the "Connection: Keep-Alive" HTTP header.
2. If keep-alive is not enabled it is likely your HTTP headers are stating "connection: close" 
3. Change that to "connection: keep-alive" to enable keep-alive. 
4. Enabling keep-alive depends on what server you are using and what you have access to. We  cover the most common methods below.

Related to #519 