### PR TITLE
Disable HTTP ETag header

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -84,3 +84,7 @@ Header set Cache-Control "max-age=31536000, public"
 <filesMatch ".(css|js)$">
 Header set Cache-Control "max-age=2628000, public"
 </filesMatch>
+
+# BEGIN Turn ETags Off
+FileETag None
+# END Turn ETags Off


### PR DESCRIPTION
ETags were added to provide a mechanism for validating entities that is more flexible than the last-modified date.

The problem with ETags is that they typically are constructed using attributes that make them unique to a specific server hosting a site.

ETags won’t match when a browser gets the original component from one server and later tries to validate that component on a different server.