### PR TITLE
added base64 footer image

### DIFF
--- a/scripts/app.js
+++ b/scripts/app.js
@@ -113,7 +113,7 @@ let footer = $(`
 <div class="container">
   <div class="row">
 	<div class="col-lg-6 col-md-4 footer-logo"> 
-		<img src="assets/Images/logo/logo.png" alt="Girl Script Chennai Chapter Logo" class="logo" aria-label="Girl Script Chennai Chapter Logo">
+		<img data-src="assets/Images/logo/logo.png" src="data:image/png;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=" alt="Girl Script Chennai Chapter Logo" class="logo" aria-label="Girl Script Chennai Chapter Logo">
 	</div>
 	<div class="col-lg-6 col-md-8 mb-5" id="footer-c">		
 	  <br> 
@@ -234,3 +234,12 @@ function topBtnClick() {
 	document.body.scrollTop = 0;
 	document.documentElement.scrollTop = 0;
 }
+
+
+function init() {
+var imgDefer = document.getElementsByTagName('img');
+for (var i=0; i<imgDefer.length; i++) {
+if(imgDefer[i].getAttribute('data-src')) {
+imgDefer[i].setAttribute('src',imgDefer[i].getAttribute('data-src'));
+} } }
+window.onload = init;

--- a/scripts/registrations.js
+++ b/scripts/registrations.js
@@ -71,7 +71,7 @@ let footer = $(`
 <div class="container">
   <div class="row">
 	<div class="col-lg-6 col-md-4 footer-logo"> 
-		<img src="assets/Images/logo/logo.png" alt="Girl Script Chennai Chapter Logo" class="logo" aria-label="Girl Script Chennai Chapter Logo">
+		<img data-src="assets/Images/logo/logo.png" src="data:image/png;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=" alt="Girl Script Chennai Chapter Logo" class="logo" aria-label="Girl Script Chennai Chapter Logo">
 	</div>
 	<div class="col-lg-6 col-md-8 mb-5" id="footer-c">		
 	  <br> 
@@ -281,3 +281,13 @@ var questions = [
 		setTimeout(callback, tTime * 7);
 	}
 })();
+
+
+function init() {
+	var imgDefer = document.getElementsByTagName('img');
+	for (var i=0; i<imgDefer.length; i++) {
+	if(imgDefer[i].getAttribute('data-src')) {
+	imgDefer[i].setAttribute('src',imgDefer[i].getAttribute('data-src'));
+	} } }
+	window.onload = init;
+	


### PR DESCRIPTION
When a webpage is rendered in a browser the browser will attempt to download all the images it can find on the page. If there are two images on the page, it will download two images. If there are one hundred images on the page it will download all one hundred.

This is default browser behavior. It has to request and download all images.

The only reliable way around this (for all browsers) is to trick the browser into thinking those images aren't there.

As lazy load is not preferred so we have used base64 image.

To do this we need to markup our images and add a small and extremely simple javascript.. It uses a base 64 image.
