### PR TITLE
added the lighthouse for performance budgets

### DIFF
--- a/src/budget.json
+++ b/src/budget.json
@@ -1,0 +1,31 @@
+[
+  {
+    "path": "/*",
+    "timings": [
+      {
+        "metric": "interactive",
+        "budget": 3000
+      },
+      {
+        "metric": "first-meaningful-paint",
+        "budget": 1000
+      }
+    ],
+    "resourceSizes": [
+      {
+        "resourceType": "script",
+        "budget": 125
+      },
+      {
+        "resourceType": "total",
+        "budget": 300
+      }
+    ],
+    "resourceCounts": [
+      {
+        "resourceType": "third-party",
+        "budget": 10
+      }
+    ]
+  }
+]


### PR DESCRIPTION
Lighthouse now supports performance budgets. 
This feature, LightWallet, can be set up in under five minutes and provides feedback on performance metrics and the size and quantity of page resources.

This example budget.json file sets five separate budgets:
1. A budget of 3000ms for Time to Interactive.
2. A budget of 1000ms for First Meaningful Paint
3. A budget of 125 KB for the total amount of JavaScript on the page.
4. A budget of 300 KB for the overall size of the page.
5. A budget of 10 requests for the numer of requests made to third-party origins.