### PR TITLE
Backend: API Endpoint for subscribing to newsletter done

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,0 @@
-DB_PASSWORD=boilerplate-backend
-DB_USERNAME=boilerplate-admin
-DB=mongodb+srv://boilerplate-admin:<PASSWORD>@boilerplate-backend-x6yhe.mongodb.net/test?retryWrites=true&w=majority

--- a/.env
+++ b/.env
@@ -1,0 +1,3 @@
+DB_PASSWORD=boilerplate-backend
+DB_USERNAME=boilerplate-admin
+DB=mongodb+srv://boilerplate-admin:<PASSWORD>@boilerplate-backend-x6yhe.mongodb.net/test?retryWrites=true&w=majority

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 node_modules
-.env
 .vscode

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 node_modules
-.env
+
 .vscode

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 node_modules
-
+.env
 .vscode

--- a/app.js
+++ b/app.js
@@ -9,9 +9,17 @@ const app = express();
 app.use(morgan('dev'));
 app.use(cors());
 app.use(helmet());
+app.use(express.json());
+
+// DataBase Models
+const signInToLetter = require('./controllers/newsletter');
 
 // Exmaple route for setup test
 app.get('/', (req, res) => {
 	res.json({ message: 'Application Setup is correct' });
 });
+
+// the API EndPoint to sigin to newsletter
+app.post('/newsletter', signInToLetter);
+
 module.exports = app;

--- a/controllers/newsletter.js
+++ b/controllers/newsletter.js
@@ -1,0 +1,19 @@
+const Newsletter = require('../models/newsletterModel');
+
+const signInToLetter = async (req, res) => {
+	try {
+		const newSubscriber = await Newsletter.create(req.body);
+		res.status(201).json({
+			status: 'success',
+			message: 'The user is now subscribed to newsletter',
+			data: newSubscriber
+		});
+	} catch (err) {
+		res.status(404).json({
+			status: 'fail',
+			err
+		});
+	}
+};
+
+module.exports = signInToLetter;

--- a/models/newsletterModel.js
+++ b/models/newsletterModel.js
@@ -1,0 +1,18 @@
+const mongoose = require('mongoose');
+const { isEmail } = require('validator');
+
+const newsletterSchema = new mongoose.Schema({
+	email: {
+		type: String,
+		required: [true, 'An email is needed for newsletter'],
+		validate: {
+			validator: function (value) {
+				return isEmail(value);
+			},
+			message: 'The email should be in valid format'
+		}
+	}
+});
+
+const Newsletter = mongoose.model('Newsletter', newsletterSchema);
+module.exports = Newsletter;

--- a/package-lock.json
+++ b/package-lock.json
@@ -3368,6 +3368,11 @@
         "spdx-expression-parse": "^3.0.0"
       }
     },
+    "validator": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.0.0.tgz",
+      "integrity": "sha512-anYx5fURbgF04lQV18nEQWZ/3wHGnxiKdG4aL8J+jEDsm98n/sU/bey+tYk6tnGJzm7ioh5FoqrAiQ6m03IgaA=="
+    },
     "vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
 	"main": "app.js",
 	"scripts": {
 		"test": "echo \"Error: no test specified\" && exit 1",
-		"start": "nodemon server.js"
+		"start": "node server.js",
+		"start:dev": "nodemon server.js"
 	},
 	"repository": {
 		"type": "git",
@@ -19,7 +20,8 @@
 		"express": "^4.17.1",
 		"helmet": "^3.22.0",
 		"mongoose": "^5.9.16",
-		"morgan": "^1.10.0"
+		"morgan": "^1.10.0",
+		"validator": "^13.0.0"
 	},
 	"devDependencies": {
 		"eslint": "^6.8.0",


### PR DESCRIPTION
This PR includes:
- API Endpoint for signing up for the newsletter is completed
- Validators are made on the server as well just for safety
- the body must be an email in the form `{email:<email_id>}`
- It is added to a collection called newsletter on ATLAS cloud

Endpoint Properties:
the request object must contain the format shown above and in return, it will send back information to the client using JSend Technique. Look at screenshots attached below. (postman response )

@anushbhatia  Sir I will deploy all new endpoints to Heroku so we can start using them immediately
The endpoint hit should be at `https://desolate-waters-45820.herokuapp.com/newsletter`


![Screenshot (210)](https://user-images.githubusercontent.com/49617450/83332420-b73afd00-a2b8-11ea-8fc6-c4840962b5ce.png)
![Screenshot (211)](https://user-images.githubusercontent.com/49617450/83332421-b99d5700-a2b8-11ea-9039-abaac06796a5.png)
