### PR TITLE
Backend: Not allowing dual newsletter subscribe

### DIFF
--- a/controllers/newsletter.js
+++ b/controllers/newsletter.js
@@ -9,6 +9,15 @@ const signInToLetter = async (req, res) => {
 			data: newSubscriber
 		});
 	} catch (err) {
+		if (
+			err.code === 11000 &&
+			err.errmsg.includes('E11000 duplicate key error')
+		) {
+			return res.status(404).json({
+				status: 'fail',
+				message: 'The user is already subscribed'
+			});
+		}
 		res.status(404).json({
 			status: 'fail',
 			message: 'Subscribing to newsletter has failed',

--- a/models/newsletterModel.js
+++ b/models/newsletterModel.js
@@ -10,7 +10,8 @@ const newsletterSchema = new mongoose.Schema({
 				return isEmail(value);
 			},
 			message: 'The email should be in valid format'
-		}
+		},
+		unique: [true, 'The email is already subscribed']
 	}
 });
 


### PR DESCRIPTION
This PR includes:
 it does not allow users with the same email id to subscribe twice to the newsletter.
The API Endpoint is deployed and updated.

@anushbhatia Sir I have cleared the newsletter collections you can test in by signing in twice with same email id 

The custom message on the main website needs to be updated it might just show error message now (needs to be updated on main website and react version) 
You can see full functionality using POSTMAN

API: `https://desolate-waters-45820.herokuapp.com/newsletter`

![Screenshot (216)](https://user-images.githubusercontent.com/49617450/83354648-b74e0200-a377-11ea-90ab-7310e110a797.png)


